### PR TITLE
Fix escaping keys in MarshalJSON

### DIFF
--- a/orderedmap.go
+++ b/orderedmap.go
@@ -315,25 +315,24 @@ func sliceStringToSliceWithOrderedMaps(valueStr string, newSlice *[]interface{})
 }
 
 func (o OrderedMap) MarshalJSON() ([]byte, error) {
-	s := "{"
-	for _, k := range o.keys {
-		// add key
-		kEscaped := strings.Replace(k, `"`, `\"`, -1)
-		s = s + `"` + kEscaped + `":`
-		// add value
-		v := o.values[k]
-		buffer := new(bytes.Buffer)
-		encoder := json.NewEncoder(buffer)
-		encoder.SetEscapeHTML(o.escapeHTML)
-		err := encoder.Encode(v)
-		if err != nil {
-			return []byte{}, err
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(o.escapeHTML)
+	for i, k := range o.keys {
+		if i > 0 {
+			buf.WriteByte(',')
 		}
-		s = s + buffer.String() + ","
+		// add key
+		if err := encoder.Encode(k); err != nil {
+			return nil, err
+		}
+		buf.WriteByte(':')
+		// add value
+		if err := encoder.Encode(o.values[k]); err != nil {
+			return nil, err
+		}
 	}
-	if len(o.keys) > 0 {
-		s = s[0 : len(s)-1]
-	}
-	s = s + "}"
-	return []byte(s), nil
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
 }

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -132,8 +132,8 @@ func TestMarshalJSON(t *testing.T) {
 	v.Set("e", 1)
 	v.Set("a", 2)
 	o.Set("orderedmap", v)
-	// double quote in key
-	o.Set(`test"ing`, 9)
+	// escape key
+	o.Set("test\n\r\t\\\"ing", 9)
 	// convert to json
 	b, err := json.Marshal(o)
 	if err != nil {
@@ -141,7 +141,7 @@ func TestMarshalJSON(t *testing.T) {
 	}
 	s := string(b)
 	// check json is correctly ordered
-	if s != `{"number":4,"string":"x","specialstring":"\\.\u003c\u003e[]{}_-","z":1,"a":2,"b":3,"slice":["1",1],"orderedmap":{"e":1,"a":2},"test\"ing":9}` {
+	if s != `{"number":4,"string":"x","specialstring":"\\.\u003c\u003e[]{}_-","z":1,"a":2,"b":3,"slice":["1",1],"orderedmap":{"e":1,"a":2},"test\n\r\t\\\"ing":9}` {
 		t.Error("JSON Marshal value is incorrect", s)
 	}
 	// convert to indented json
@@ -165,7 +165,7 @@ func TestMarshalJSON(t *testing.T) {
     "e": 1,
     "a": 2
   },
-  "test\"ing": 9
+  "test\n\r\t\\\"ing": 9
 }`
 	if si != ei {
 		fmt.Println(ei)


### PR DESCRIPTION
This is a fix for https://github.com/iancoleman/orderedmap/issues/17#issuecomment-757491931, the issue about MarshalJSON. Also improves the performance by reducing the allocations. ~This change follows #19.~

<details>
<summary>BenchmarkUnmarshalJSON</summary>

```go
func BenchmarkMarshalJSON(b *testing.B) {
	s := `{
  "number": 4,
  "string": "x",
  "z": 1,
  "a": "should not break with unclosed { character in value",
  "b": 3,
  "slice": [
    "1",
    1
  ],
  "orderedmap": {
    "e": 1,
    "a { nested key with brace": "with a }}}} }} {{{ brace value",
	"after": {
		"link": "test {{{ with even deeper nested braces }"
	}
  },
  "test\"ing": 9,
  "after": 1,
  "multitype_array": [
    "test",
	1,
	{ "map": "obj", "it" : 5, ":colon in key": "colon: in value" },
	[{"inner": "map"}]
  ],
  "should not break with { character in key": 1
}`
	o := New()
	json.Unmarshal([]byte(s), &o)
	for i := 0; i < b.N; i++ {
		json.Marshal(o)
	}
}
```
</details>

```
benchmark                   old ns/op     new ns/op     delta
BenchmarkMarshalJSON-16     15687         14535         -7.34%

benchmark                   old allocs     new allocs     delta
BenchmarkMarshalJSON-16     94             33             -64.89%

benchmark                   old bytes     new bytes     delta
BenchmarkMarshalJSON-16     9309          2195          -76.42%
```