### PR TITLE
Fix crash bugs on duplicate keys

### DIFF
--- a/orderedmap.go
+++ b/orderedmap.go
@@ -213,14 +213,19 @@ func decodeSlice(dec *json.Decoder, s []interface{}, escapeHTML bool) error {
 							return err
 						}
 						s[index] = newMap
+					} else if err = decodeOrderedMap(dec, &OrderedMap{}); err != nil {
+						return err
 					}
 				} else if err = decodeOrderedMap(dec, &OrderedMap{}); err != nil {
 					return err
 				}
 			case '[':
 				if index < len(s) {
-					values := s[index].([]interface{})
-					if err = decodeSlice(dec, values, escapeHTML); err != nil {
+					if values, ok := s[index].([]interface{}); ok {
+						if err = decodeSlice(dec, values, escapeHTML); err != nil {
+							return err
+						}
+					} else if err = decodeSlice(dec, []interface{}{}, escapeHTML); err != nil {
 						return err
 					}
 				} else if err = decodeSlice(dec, []interface{}{}, escapeHTML); err != nil {

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -333,12 +333,14 @@ func TestUnmarshalJSONDuplicateKeys(t *testing.T) {
 		"b": {"x":[1]},
 		"c": "x",
 		"d": {"x":1},
+		"b": [{"x":[]}],
 		"c": 1,
 		"d": {"y": 2},
 		"e": [{"x":1}],
+		"e": [[]],
 		"e": [{"z":2}],
 		"a": {},
-		"b": []
+		"b": [[1]]
 	}`
 	o := New()
 	err := json.Unmarshal([]byte(s), &o)


### PR DESCRIPTION
Thanks for merging #19. The pr was big rewrite and I missed some corner case bugs, sorry. This p/r fixes some crash which happens with **duplicate keys**. When JSON does not have duplicate keys, these branches are unreachable. `TestUnmarshalJSONDuplicateKeys` was intended to cover the cases but not enough. We can't skip decoding when the type is different.