### PR TITLE
Range

### DIFF
--- a/orderedmap.go
+++ b/orderedmap.go
@@ -76,6 +76,9 @@ func (o *OrderedMap) Delete(key string) {
 	delete(o.values, key)
 }
 
+// Range over the ordered map, accessing entries in the same order they were
+// added, making the traversal deterministic.
+// This API is based on the api `sync.Map.Range`.
 func (o *OrderedMap) Range(f func(key string, value interface{}) bool) {
 	for _, k := range o.keys {
 		v := o.values[k]

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -76,6 +76,15 @@ func (o *OrderedMap) Delete(key string) {
 	delete(o.values, key)
 }
 
+func (o *OrderedMap) Range(f func(key string, value interface{}) bool) {
+	for _, k := range o.keys {
+		v := o.values[k]
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
 func (o *OrderedMap) Keys() []string {
 	return o.keys
 }

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -79,10 +79,16 @@ func (o *OrderedMap) Delete(key string) {
 // Range over the ordered map, accessing entries in the same order they were
 // added, making the traversal deterministic.
 // This API is based on the api `sync.Map.Range`.
-func (o *OrderedMap) Range(f func(key string, value interface{}) bool) {
+//
+// Provide a call function, `fn`, which will receive the key and value of each
+// iteration. The callback function returns a bool indicating whether or not to
+// continue looping.
+// `true`: continue iteration
+// `false`: break from interation
+func (o *OrderedMap) Range(fn func(key string, value interface{}) bool) {
 	for _, k := range o.keys {
 		v := o.values[k]
-		if !f(k, v) {
+		if !fn(k, v) {
 			break
 		}
 	}


### PR DESCRIPTION
Add a `Range` function for ordered traversal.

I know that #8 is already opened and adds an iterator, however, this solution is both simplified and conforms to a pattern already in Golang, [`sync.Map.Range`](https://pkg.go.dev/sync#Map.Range).

Usage:

```go
om.Range(func(k string, v interface{}) bool {
	fmt.Printf("key=%s, val=%v\n", k, v)
	return true
})
```

If a user wants to `break`, then they can just return `false` from the passed function.